### PR TITLE
Add `osname()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ fn main() {
     println!("{}", uname.release());
     println!("{}", uname.version());
     println!("{}", uname.machine());
+    println!("{}", uname.osname());
 }
 ```
 should return something like:
@@ -31,6 +32,7 @@ hostname
 5.10.0-8-amd64
 #1 SMP Debian 5.10.46-4 (2021-08-03)
 x86_64
+GNU/Linux
 ```
 
 License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,4 +56,29 @@ pub trait Uname {
 
     /// The name of the current system's hardware.
     fn machine(&self) -> Cow<str>;
+
+    /// The name of the current OS.
+    fn osname(&self) -> Cow<str>;
 }
+
+// ref: [`uname` info](https://en.wikipedia.org/wiki/Uname)
+#[cfg(all(target_os = "linux", any(target_env = "gnu", target_env = "")))]
+const HOST_OS: &str = "GNU/Linux";
+#[cfg(all(target_os = "linux", not(any(target_env = "gnu", target_env = ""))))]
+const HOST_OS: &str = "Linux";
+#[cfg(target_os = "android")]
+const HOST_OS: &str = "Android";
+#[cfg(target_os = "windows")]
+const HOST_OS: &str = "MS/Windows"; // prior art == `busybox`
+#[cfg(target_os = "freebsd")]
+const HOST_OS: &str = "FreeBSD";
+#[cfg(target_os = "netbsd")]
+const HOST_OS: &str = "NetBSD";
+#[cfg(target_os = "openbsd")]
+const HOST_OS: &str = "OpenBSD";
+#[cfg(target_vendor = "apple")]
+const HOST_OS: &str = "Darwin";
+#[cfg(target_os = "fuchsia")]
+const HOST_OS: &str = "Fuchsia";
+#[cfg(target_os = "redox")]
+const HOST_OS: &str = "Redox";

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -65,4 +65,8 @@ impl Uname for PlatformInfo {
     fn machine(&self) -> Cow<str> {
         cstr2cow!(self.inner.machine)
     }
+
+    fn osname(&self) -> Cow<str> {
+        Cow::Borrowed(crate::HOST_OS)
+    }
 }

--- a/src/unknown.rs
+++ b/src/unknown.rs
@@ -37,6 +37,10 @@ impl Uname for PlatformInfo {
     fn machine(&self) -> Cow<str> {
         Cow::Borrowed("unknown")
     }
+
+    fn osname(&self) -> Cow<str> {
+        Cow::Borrowed("unknown")
+    }
 }
 
 #[test]
@@ -48,4 +52,5 @@ fn test_unknown() {
     assert_eq!(platform_info.release(), "unknown");
     assert_eq!(platform_info.version(), "unknown");
     assert_eq!(platform_info.machine(), "unknown");
+    assert_eq!(platform_info.osname(), "unknown");
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -311,10 +311,10 @@ impl PlatformInfo {
             },
             10 => match minor {
                 0 if product_type == VER_NT_WORKSTATION && (build >= 22000) => "Windows 11",
-                0 if product_type != VER_NT_WORKSTATION && (build >= 14000 && build < 17000) => {
+                0 if product_type != VER_NT_WORKSTATION && (14000..17000).contains(&build) => {
                     "Windows Server 2016"
                 }
-                0 if product_type != VER_NT_WORKSTATION && (build >= 17000 && build < 19000) => {
+                0 if product_type != VER_NT_WORKSTATION && (17000..19000).contains(&build) => {
                     "Windows Server 2019"
                 }
                 0 if product_type != VER_NT_WORKSTATION && (build >= 20000) => {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -54,6 +54,7 @@ struct VS_FIXEDFILEINFO {
 }
 
 struct WinOSVersionInfo {
+    os_name: String,
     release: String,
     version: String,
 }
@@ -86,7 +87,7 @@ impl PlatformInfo {
                 nodename,
                 version: version_info.version,
                 release: version_info.release,
-                osname: crate::HOST_OS.to_string(),
+                osname: format!("{} ({})", crate::HOST_OS, version_info.os_name),
             })
         }
     }
@@ -134,6 +135,13 @@ impl PlatformInfo {
 
                 if func(&mut osinfo) == STATUS_SUCCESS {
                     return Ok(WinOSVersionInfo {
+                        os_name: Self::determine_os_name(
+                            osinfo.dwMajorVersion,
+                            osinfo.dwMinorVersion,
+                            osinfo.dwBuildNumber,
+                            osinfo.wProductType,
+                            osinfo.wSuiteMask,
+                        ),
                         release: format!("{}.{}", osinfo.dwMajorVersion, osinfo.dwMinorVersion),
                         version: format!("{}", osinfo.dwBuildNumber),
                     });
@@ -177,8 +185,9 @@ impl PlatformInfo {
         };
 
         Ok(WinOSVersionInfo {
-            version: format!("{}", build),
+            os_name: Self::determine_os_name(major, minor, build, product_type, suite_mask),
             release: format!("{}.{}", major, minor),
+            version: format!("{}", build),
         })
     }
 
@@ -266,20 +275,28 @@ impl PlatformInfo {
         ))
     }
 
-    fn determine_release(
+    fn determine_os_name(
         major: ULONG,
         minor: ULONG,
+        build: ULONG,
         product_type: UCHAR,
         suite_mask: USHORT,
     ) -> String {
-        let mut name = match major {
+        // [NT Version Info (detailed)](https://en.wikipedia.org/wiki/Comparison_of_Microsoft_Windows_versions#Windows_NT) @@ <https://archive.is/FSkhj>
+        let default_name = if product_type == VER_NT_WORKSTATION {
+            format!("{} {}.{}", "Windows", major, minor)
+        } else {
+            format!("{} {}.{}", "Windows Server", major, minor)
+        };
+
+        let name = match major {
             5 => match minor {
                 0 => "Windows 2000",
                 1 => "Windows XP",
                 2 if product_type == VER_NT_WORKSTATION => "Windows XP Professional x64 Edition",
                 2 if suite_mask as UINT == VER_SUITE_WH_SERVER => "Windows Home Server",
                 2 => "Windows Server 2003",
-                _ => "",
+                _ => &default_name,
             },
             6 => match minor {
                 0 if product_type == VER_NT_WORKSTATION => "Windows Vista",
@@ -290,25 +307,25 @@ impl PlatformInfo {
                 2 => "Windows 8",
                 3 if product_type != VER_NT_WORKSTATION => "Windows Server 2012 R2",
                 3 => "Windows 8.1",
-                _ => "",
+                _ => &default_name,
             },
             10 => match minor {
-                0 if product_type != VER_NT_WORKSTATION => "Windows Server 2016",
-                _ => "",
+                0 if product_type == VER_NT_WORKSTATION && (build >= 22000) => "Windows 11",
+                0 if product_type != VER_NT_WORKSTATION && (build >= 14000 && build < 17000) => {
+                    "Windows Server 2016"
+                }
+                0 if product_type != VER_NT_WORKSTATION && (build >= 17000 && build < 19000) => {
+                    "Windows Server 2019"
+                }
+                0 if product_type != VER_NT_WORKSTATION && (build >= 20000) => {
+                    "Windows Server 2022"
+                }
+                _ => "Windows 10",
             },
-            _ => "",
+            _ => &default_name,
         };
 
-        // we're doing this down here so we don't have to copy this into multiple branches
-        if name.is_empty() {
-            name = if product_type == VER_NT_WORKSTATION {
-                "Windows"
-            } else {
-                "Windows Server"
-            };
-        }
-
-        format!("{} {}.{}", name, major, minor)
+        name.to_string()
     }
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -64,6 +64,7 @@ pub struct PlatformInfo {
     nodename: String,
     release: String,
     version: String,
+    osname: String,
 }
 
 impl PlatformInfo {
@@ -85,6 +86,7 @@ impl PlatformInfo {
                 nodename,
                 version: version_info.version,
                 release: version_info.release,
+                osname: crate::HOST_OS.to_string(),
             })
         }
     }
@@ -360,6 +362,10 @@ impl Uname for PlatformInfo {
         };
 
         Cow::from(arch_str)
+    }
+
+    fn osname(&self) -> Cow<str> {
+        Cow::from(self.osname.as_str())
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -12,12 +12,14 @@ fn platform() -> Result<(), String> {
     println!("release = {}", uname.release());
     println!("version = {}", uname.version());
     println!("machine = {}", uname.machine());
+    println!("osname = {}", uname.osname());
 
     assert!(!uname.sysname().is_empty());
     assert!(!uname.nodename().is_empty());
     assert!(!uname.release().is_empty());
     assert!(!uname.version().is_empty());
     assert!(!uname.machine().is_empty());
+    assert!(!uname.osname().is_empty());
 
     Ok(())
 }


### PR DESCRIPTION
Move `osname()` down from uutils `uname` into platform-info to reduce `uname` complexity and add additional WinOS info.

With this and updates to `uname`, a future `uname -a` would look like...

```shell
> uname -a
Windows_NT HOSTNAME 10.0 19044 x86_64 MS/Windows (Windows 10)
```


